### PR TITLE
Updated README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the source repository for the MyDecisive documentation. The documentatio
 The quick way to get started:
 
 1. Clone this repository with Git.
-2. Re-download the Relearn theme (see [Update the Theme](#update-the-theme))
+2. Re-download the Relearn theme (see instructions in [Update the Theme](#update-the-theme))
 3. Install Hugo (extended edition).
 4. Test changes locally by building and loading the site with Hugo.
 5. Create a PR to get your changes reviewed before they're merged.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This is the source repository for the MyDecisive documentation. The documentatio
 
 The quick way to get started:
 
-1. Clone this repository with Git. 
-2. Install Hugo (extended edition).
-3. Test changes locally by building and loading the site with Hugo.
-4. Create a PR to get your changes reviewed before they're merged.
+1. Clone this repository with Git.
+2. Re-download the Relearn theme (see [Update the Theme](#update-the-theme))
+3. Install Hugo (extended edition).
+4. Test changes locally by building and loading the site with Hugo.
+5. Create a PR to get your changes reviewed before they're merged.
 
 Depending on what you intend to do (beyond just documentation and plain CSS), the Hugo documentation has more information on other resources you may need.
 
@@ -19,20 +20,20 @@ These are the most relevant directories and files:
 
 - `hugo.toml` - the main config file
 - `assets/css` - css files to override theme styles; theme files are copied here and updated; never edit the original as it'll be overwritten with a theme update
-- `layouts/partial/logo.html` - HTML to override theme layouts, with `logo.html` being the custom logo for the header 
+- `layouts/partial/logo.html` - HTML to override theme layouts, with `logo.html` being the custom logo for the header
 - `static/images` - stores site images
 - `themes` - stores Relearn theme files; imports the theme via git module
 - `content` - the Markdown and image files forming the site; site structure follows the directory structure (see Hugo docs for more info)
 
 ## Work with Style
 
-Custom css files are stored in `assets/css`. When making a change to a value, add a note in the associated comment to indicate that it's a MyDecisive custom value. An example: 
+Custom css files are stored in `assets/css`. When making a change to a value, add a note in the associated comment to indicate that it's a MyDecisive custom value. An example:
 
 ```
 assets/css/theme-relearn-dark.css:  --PRIMARY-color: rgba(19, 19, 19, 1); /* brand primary color; this is the color used in the element surrounding the search box in the upper left; set to MyDecisive black */
 ...
 assets/css/theme-relearn-dark.css:  --SECONDARY-color: rgba(176, 98, 194, 1); /* brand secondary color; used for links; using MyDecisive brand light purple */
-``` 
+```
 
 These comments in these examples indicate that the color values were changed from the default.
 
@@ -40,7 +41,14 @@ These comments in these examples indicate that the color values were changed fro
 
 The Hugo [Relearn theme](https://github.com/McShelby/hugo-theme-relearn) is installed as a git module. See the theme website for more info on versions.
 
-To update it to the latest version, run:
+If you cloned this repo, the Relearn theme will need to be re-downloaded. Run:
+
+```
+git module init
+git submodule update --remote --merge
+```
+
+To update it Relearn to the latest version, run:
 
 ```
 git submodule update --remote --merge


### PR DESCRIPTION
 I learned that if one clones the docs repo, the Relearn theme needs to be re-downloaded.   Updated README to include instructions for dealing with updating the Relearn submodule.  