### PR TITLE
docs: fix helm to install a specific version of mdai

### DIFF
--- a/content/quickstart/collect.md
+++ b/content/quickstart/collect.md
@@ -31,7 +31,7 @@ An OpenTelemetry collector is a component that receives and forwards telemetry d
     gateway-collector-74f69ccf5b-896gk   1/1     Running   0          2m28s
     ```
 
-## Collect Logs
+## Forward Logs
 
 We'll use Fluentd to capture the synthetic log streams you created, and forward them to the collector.
 

--- a/content/quickstart/install.md
+++ b/content/quickstart/install.md
@@ -18,7 +18,7 @@ Make sure Docker is running.
 
 2. Use kubectl to install cert-manager. Wait a few moments for cert-manager to finish installing.
     ```
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.0/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
     ```
 
 3. Install `mdai` helm repo and ensure it's up to date.
@@ -32,7 +32,7 @@ Make sure Docker is running.
 
 4. Create the mdai namespace.
    ```
-   helm upgrade --install --create-namespace --namespace mdai --cleanup-on-fail --wait-for-jobs mdai mdai/mdai-hub --devel
+   helm upgrade --install --create-namespace --namespace mdai --cleanup-on-fail --wait-for-jobs mdai mdai/mdai-hub --version v0.7.1-rc2
    ```
    > [!NOTE]
    > If running this command returns an error telling you to run `helm repo update`, then try again.


### PR DESCRIPTION
Update helm to use version `--version v0.7.1-rc2` vs. `--devel`