### PR TITLE
sp/ENG-693: Added simple skeleton for recipes pages. Updated styling for side menu

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -36,6 +36,12 @@
   margin-top: 0;
 }
 
+/*** Hextra Left Side Menu overrides ***/
+.sidebar-active-item {
+  background-color: transparent !important;
+  color: var(--mdai-primary-color) !important;
+}
+
 /*** Hextra Tabs overrides ***/
 .hx-border-b {
    border-bottom-width: 0;

--- a/content/docs/recipes/_index.md
+++ b/content/docs/recipes/_index.md
@@ -1,4 +1,22 @@
 ---
-title: Recipes
+title: Recipe List
 weight: 3
 ---
+
+Basic (Use cases/Solutions)
+
+| Setup | Category/Tags | Who contributed |
+| :---- | :------------ | :-------------- |
+| Recipe Example ([LINK TO RECIPE TEMPLATE](recipe-example))  | Example  | MDAI |
+| Use case 1 (LINK TO RECIPE TEMPLATE)  | Compliance  | MDAI |
+| Use case 2 (LINK TO RECIPE TEMPLATE) | Trace trigger  | MDAI |
+| Use case 3 (LINK TO RECIPE TEMPLATE) | Data filtration | MDAI |
+
+Advanced (extending MDAI platform/use MDAI to the full potential)
+
+| Setup | Category/Tags | Who contributed |
+| :---- | :------------ | :-------------- |
+| Use case 1 (LINK TO RECIPE TEMPLATE)  | Compliance  | MDAI |
+| Use case 2 (LINK TO RECIPE TEMPLATE) | Trace trigger  | MDAI |
+| Use case 3 (LINK TO RECIPE TEMPLATE) | Data filtration | MDAI |
+| Use case 4 (LINK TO RECIPE TEMPLATE) | Scaling | MDAI |

--- a/content/docs/recipes/recipe-example.md
+++ b/content/docs/recipes/recipe-example.md
@@ -1,0 +1,49 @@
+---
+title: Recipe Example Page
+weight: 1
+---
+#### Use case
+Use case description goes here
+
+#### Check for dependencies
+Make sure you have your dependencies installed and MDAI Smart Hub running...
+
+#### Choose your preferred installation method
+
+{{< tabs items="Guided - Step-by-step, Automated - Scripted" >}}
+
+<!-- Tab A -->
+  {{< tab >}}
+
+    <p class="mdai-description-text">Default config and you get these things</p>
+
+    ```bash
+    some code
+    ```
+
+##### Get insights (Dashboard)
+
+    ```bash
+    some more code
+    ```
+
+##### Level-up with Dynamic (parameterized config)
+
+    ```bash
+    some more code
+    ```
+
+  {{< /tab >}}
+
+<!-- Tab B -->
+  {{< tab >}}
+
+AWAITING CONTENT
+
+  {{< /tab >}}
+{{< /tabs >}}
+
+##### Advanced setup (Hungry for more?)
+Power up MDAI with these other relevant recipes
+- [Relevant link to advanced]()
+- [Maybe another relevant link to use case]() 


### PR DESCRIPTION
- Added very basic recipe list page. We do not have mdai-labs fleshed out enough yet for me to start plugging in api like stuff. Need more info on the structure
- Added example recipe page
- Due to docs meeting outcomes, not styling this just yet, fast follow along with api pulling mocks like functionality
<img width="1319" height="1051" alt="Screenshot 2025-08-15 at 2 47 01 PM" src="https://github.com/user-attachments/assets/be99c558-497b-49d9-8d88-ff9d177a80b3" />
<img width="1317" height="1278" alt="Screenshot 2025-08-15 at 2 47 11 PM" src="https://github.com/user-attachments/assets/71523022-2569-473d-ae2b-c856168810b1" />
